### PR TITLE
Change name of Turkey to new official name Türkiye

### DIFF
--- a/install-stubs/resources/lang/da.json
+++ b/install-stubs/resources/lang/da.json
@@ -553,7 +553,7 @@
     "Tonga": "Tonga",
     "Trinidad and Tobago": "Trinidad and Tobago",
     "Tunisia": "Tunisia",
-    "Turkey": "Turkey",
+    "Turkey": "Türkiye",
     "Turkmenistan": "Turkmenistan",
     "Turks and Caicos Islands": "Turks and Caicos Islands",
     "Tuvalu": "Tuvalu",

--- a/install-stubs/resources/lang/en.json
+++ b/install-stubs/resources/lang/en.json
@@ -572,7 +572,7 @@
     "Tonga": "Tonga",
     "Trinidad and Tobago": "Trinidad and Tobago",
     "Tunisia": "Tunisia",
-    "Turkey": "Turkey",
+    "Turkey": "Türkiye",
     "Turkmenistan": "Turkmenistan",
     "Turks and Caicos Islands": "Turks and Caicos Islands",
     "Tuvalu": "Tuvalu",


### PR DESCRIPTION
The countries name change to Türkiye was accepted and confirmed by the UN on 26 May 2022 https://www.un.org/en/about-us/member-states/turkiye

I first suggested the change in the Laravel-Lang/lang project where it's currently in review.

The suggestion there was to also create a pull request here because the projects synchronize the translation contents:

https://github.com/Laravel-Lang/lang/pull/2545#issuecomment-1364143383

It'd be good if we wait to see if it gets accepted there.